### PR TITLE
remove Marked: uninstall and use Typora for markdown

### DIFF
--- a/mac/install.yaml
+++ b/mac/install.yaml
@@ -379,22 +379,6 @@ install_groups:
           - Install (`brew install --cask whatsyoursign`)
           - Run Installer
 
-      - artifact: /Applications/Marked 2.app
-        install:
-          - cask: marked
-        configure:
-          - run: defaults write com.brettterpstra.marked2 WebKitDeveloperExtras -bool true
-          - run: defaults write com.brettterpstra.marked2 convertGithubCheckboxes -bool true
-          - run: defaults write com.brettterpstra.marked2 defaultProcessor -string "Discount (GFM)"
-          - run: defaults write com.brettterpstra.marked2 defaultSyntaxStyle -string "GitHub"
-          - run: defaults write com.brettterpstra.marked2 externalEditor -string "Typora"
-          - run: defaults write com.brettterpstra.marked2 externalImageEditor -string "Pixelmator"
-          - run: defaults write com.brettterpstra.marked2 includeMathJax -bool true
-          - run: defaults write com.brettterpstra.marked2 isMultiMarkdownDefault -bool false
-          - run: defaults write com.brettterpstra.marked2 syntaxHighlight -bool true
-        checklist:
-          - License
-
       - artifact: /Applications/Karabiner-Elements.app
         install:
           - cask: karabiner-elements

--- a/mac/software-suite-uninstalls.sh
+++ b/mac/software-suite-uninstalls.sh
@@ -297,6 +297,17 @@ if [ -e /Applications/Mastonaut.app ]; then
   trash "/Applications/Mastonaut.app"
 fi
 
+if [ -e "/Applications/Marked 2.app" ]; then
+  echo "Marked 2..."
+  verify_smartdelete
+  trash "/Applications/Marked 2.app"
+fi
+
+if [ -L /Applications/Marked.app ]; then
+  echo "Marked symlink..."
+  rm /Applications/Marked.app
+fi
+
 if [ -e /Applications/NepTunes.app ]; then
   echo "NepTunes..."
   verify_smartdelete

--- a/mac/software-suite.sh
+++ b/mac/software-suite.sh
@@ -211,13 +211,6 @@ else
   "$SCRIPT_DIR"/mac-install -config "$SCRIPT_DIR"/install.yaml
 fi
 
-if [ ! -L /Applications/Marked.app ]; then
-  # compatibility with old "Open in Marked" IntelliJ plugin which hardcodes this path to Marked:
-  ln -s "/Applications/Marked 2.app" /Applications/Marked.app
-  chflags -h hidden /Applications/Marked.app
-fi
-
-
 ### Uninstalls:
 "$SCRIPT_DIR"/software-suite-uninstalls.sh
 
@@ -350,20 +343,6 @@ echo "Keysmith ..."
     echo -e "- [ ] Hide in menu bar" >> "$HOME/SystemSetup.md"
     echo "" >> "$HOME/SystemSetup.md"
   fi
-fi
-
-
-if [ -e "/Applications/Setapp/Marked 2.app" ]; then
-echo "Marked (Setapp)..."
-  defaults write com.brettterpstra.marked2-setapp WebKitDeveloperExtras -bool true
-  defaults write com.brettterpstra.marked2-setapp convertGithubCheckboxes -bool true
-  defaults write com.brettterpstra.marked2-setapp defaultProcessor -string "Discount (GFM)"
-  defaults write com.brettterpstra.marked2-setapp defaultSyntaxStyle -string "GitHub"
-  defaults write com.brettterpstra.marked2-setapp externalEditor -string "Typora"
-  defaults write com.brettterpstra.marked2-setapp externalImageEditor -string "Pixelmator"
-  defaults write com.brettterpstra.marked2-setapp includeMathJax -bool true
-  defaults write com.brettterpstra.marked2-setapp isMultiMarkdownDefault -bool false
-  defaults write com.brettterpstra.marked2-setapp syntaxHighlight -bool true
 fi
 
 

--- a/mac/zsh/.zsh/markdown.zsh
+++ b/mac/zsh/.zsh/markdown.zsh
@@ -18,15 +18,6 @@ typora() {
 #   fi
 # }
 
-marked() {
-  if (( $# == 0 )); then
-    echo "Usage: marked <file>"
-    echo "Open in Marked 2"
-  else
-    open -a "Marked 2" "$1"
-  fi
-}
-
 mded() {
   if (( $# == 0 )); then
     echo "Usage: mded <file>"


### PR DESCRIPTION
- Remove Marked 2 installation from mac/install.yaml
- Add Marked to software-suite-uninstalls.sh (both app and symlink)
- Remove marked() shell function from markdown.zsh
- Remove Marked symlink creation from software-suite.sh
- Remove Setapp Marked configuration
- Typora is already configured as default for markdown files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Marked 2 application integration and configuration
  * Removed marked() command-line utility
  * Cleaned up deprecated workarounds and symlink files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->