### PR TITLE
feat(linux): install Netdata under-voltage alarm on Raspberry Pi hosts

### DIFF
--- a/linux/netdata/rpi-undervoltage.conf
+++ b/linux/netdata/rpi-undervoltage.conf
@@ -1,0 +1,39 @@
+# Raspberry Pi firmware under-voltage detection.
+#
+# The raspberrypi-hwmon driver exposes bit 0 of "vcgencmd get_throttled"
+# (UNDERVOLTAGE_NOW) as /sys/class/hwmon/hwmonN/in0_lcrit_alarm, and netdata's
+# sensors collector already records it at 1Hz. Nothing was watching it; this
+# adds the alarm. Written 2026-08-01 while investigating an abrupt shutdown of
+# surroundings.dzhome on 2026-07-31.
+#
+# Note this detects a *sustained* brownout only. An instantaneous rail collapse
+# (PMIC over-current trip, or loss of input power) gives the firmware no time to
+# latch the flag, so a clean history here does not rule out a power-related death.
+#
+# Scoped by the "driver" chart label rather than by chart name: the chart id
+# embeds the hwmon index and libsensors chip suffix (on a Pi 5:
+# sensors.voltage_rpi_volt-isa-0000_in0_alarm), neither of which is stable across
+# hosts. The label filter is also what keeps this off the other charts sharing the
+# system.hw.sensor.voltage.alarm context -- a Pi 5's rp1_adc publishes five of
+# them, and they expose only clear/fault, so an unfiltered template would attach
+# there and sit permanently UNDEFINED.
+#
+# "max" not "average" -- a single-second dip must not be averaged away.
+#
+# On a Pi lacking raspberrypi-hwmon there is no rpi_volt chart and this template
+# simply never attaches, which is the intended no-op.
+
+    template: rpi_undervoltage
+          on: system.hw.sensor.voltage.alarm
+chart labels: driver=rpi_volt
+       class: Errors
+        type: System
+   component: Power supply
+      lookup: max -60s unaligned of critical
+       units: status
+       every: 10s
+        crit: $this > 0
+      repeat: critical 1h
+       delay: down 15m
+        info: Raspberry Pi firmware reported an under-voltage condition (check the PSU and USB-C cable)
+          to: sysadmin

--- a/linux/software-install.sh
+++ b/linux/software-install.sh
@@ -176,6 +176,15 @@ if [ ! -e "$HOME/.config/dotfiles/no-netdata" ] && ! dpkg-query -W netdata >/dev
       "- [ ] Listen on port 9998\n- [ ] Make accessible via Tailscale with HTTPS (\`sudo tailscale serve --bg --https 9999 9998\`)\n- [ ] Monitor all services for this server\n- [ ] Configure per [my Netdata config document](bear://x-callback-url/open-note?id=E9620D65-2100-46CB-A798-02EFA52B6BE5-57092-00053B45CF64BCAE)"
     sudo mkdir -p /etc/netdata/health.d
     sudo cp "$SCRIPT_DIR"/netdata/user_process_count.conf /etc/netdata/health.d/user_process_count.conf
+    if is_rpi; then
+      # Alarms on the firmware under-voltage flag the sensors collector already
+      # records. No-op on a Pi without the raspberrypi-hwmon driver; see the
+      # comments in the config.
+      sudo cp "$SCRIPT_DIR"/netdata/rpi-undervoltage.conf /etc/netdata/health.d/rpi-undervoltage.conf
+    fi
+    # health.d/ is only read at startup, so the configs just copied are inert
+    # until this. Not worth failing the whole script over.
+    sudo netdatacli reload-health || true
   else
     echo "Won't ask again next time this script is run."
     touch "$HOME/.config/dotfiles/no-netdata"


### PR DESCRIPTION
The raspberrypi-hwmon driver exposes bit 0 of "vcgencmd get_throttled" (UNDERVOLTAGE_NOW) as /sys/class/hwmon/hwmonN/in0_lcrit_alarm, and Netdata's sensors collector already records it at 1Hz. Nothing was watching it. Adds a health template that does, gated on is_rpi.